### PR TITLE
Check Experimental Ammo location only if ammo was used

### DIFF
--- a/WOTCArchipelago/Src/WOTCArchipelago/Classes/X2DLCInfo_WOTCArchipelago.uc
+++ b/WOTCArchipelago/Src/WOTCArchipelago/Classes/X2DLCInfo_WOTCArchipelago.uc
@@ -377,12 +377,23 @@ static private function PatchCovertActionTemplates(X2DataTemplate DataTemplate)
 static private function PatchAbilityTemplates(X2DataTemplate DataTemplate)
 {
 	local X2AbilityTemplate AbilityTemplate;
+	local X2AbilityCost AbilityCost;
+	local X2AbilityCost_Ammo AmmoCost;
 
 	AbilityTemplate = X2AbilityTemplate(DataTemplate);
-	if (AbilityTemplate.eAbilityIconBehaviorHUD == eAbilityIconBehavior_NeverShow) return;
-	AbilityTemplate.AddShooterEffect(new class'X2Effect_ItemUseCheck');
+	// if (AbilityTemplate.eAbilityIconBehaviorHUD == eAbilityIconBehavior_NeverShow) return;
+	if (default.SkipUseAmmoCheckAbilities.Find(AbilityTemplate.DataName) != INDEX_NONE) return;
+	foreach AbilityTemplate.AbilityCosts(AbilityCost)
+	{
+		AmmoCost = X2AbilityCost_Ammo(AbilityCost);
+		if (AmmoCost == none) continue;
+		if (AmmoCost.iAmmo > 0 && !AmmoCost.bFreeCost)
+		{
+			AbilityTemplate.AddShooterEffect(new class'X2Effect_ItemUseCheck');
+			`AMLOG("Patched " $ AbilityTemplate.Name);
+		}
+	}
 
-	`AMLOG("Patched " $ AbilityTemplate.Name);
 }
 
 // Patch spawn unit ability templates to alter spawned unit


### PR DESCRIPTION
Currently, the Experimental Ammo location is checked if you have experimental ammo in your inventory and use an ability bound to a weapon that uses ammo. The problem is that there are abilities that fit the description but do not consume any ammo, like Overwatch. The ability `Overwatch` only makes the unit go on Overwatch by reserving action points for the ability `OverwatchShot`, which actually consumes the ammo.

This PR, when implemented correctly, patches abilities so that they check the Experimental Ammo location only when the weapon using the experimental ammo was fired.