### PR TITLE
[LWOTC] Add XComLW_Overhaul.ini

### DIFF
--- a/WOTCArchipelago/Config/XComLW_Overhaul.ini
+++ b/WOTCArchipelago/Config/XComLW_Overhaul.ini
@@ -1,0 +1,13 @@
+[LW_Overhaul.X2DownloadableContentInfo_LongWarOfTheChosen]
+AdvancedLasersTechName="AdvancedLasersCompleted"
+MagnetizedWeaponsTechName="MagnetizedWeaponsCompleted"
+GaussWeaponsTechName="GaussWeaponsCompleted"
+CoilgunsTechName="CoilgunsCompleted"
+AdvancedCoilgunsTechName="AdvancedCoilgunsCompleted"
+PlasmaRifleTechName="PlasmaRifleCompleted"
+AlloyCannonTechName="AlloyCannonCompleted"
+HeavyPlasmaTechName="HeavyPlasmaCompleted"
+PlasmaSniperTechName="PlasmaSniperCompleted"
+PlatedArmorTechName="PlatedArmorCompleted"
+PoweredArmorTechName="PoweredArmorCompleted"
+AdvancedGrenadesTechName="AdvancedGrenadesCompleted"


### PR DESCRIPTION
Add config that makes rebels and VIPs in LWOTC scale with items received from the multiworld, rather than research tree traversed locally.

Do not merge until https://github.com/long-war-2/lwotc/pull/1959 is in.